### PR TITLE
journalctl logs wrap

### DIFF
--- a/domain-1-cluster-setup/etcd-systemd.md
+++ b/domain-1-cluster-setup/etcd-systemd.md
@@ -42,5 +42,7 @@ systemctl status etcd
 ```sh
 journalctl -u etcd
 
+journalctl -u etcd | less
+
 systemctl restart systemd-journald.service
 ```


### PR DESCRIPTION
Add command to view the journalctl logs with long lines wrapped to fit the width of your terminal